### PR TITLE
EIP4361 Implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
   ],
+  plugins: ["no-only-tests"],
   globals: {
     document: "readonly",
     window: "readonly",
@@ -52,6 +53,8 @@ module.exports = {
       "error",
       { devDependencies: ["!+(src/api|ui)/**/*.+(ts|js)"] },
     ],
+    // dissalow it.only, assert.only, etc..
+    "no-only-tests/no-only-tests": ["error"],
     // Add known-safe exceptions to no-param-reassign.
     "no-param-reassign": [
       airbnbNoParamReassignRules[0],

--- a/README.md
+++ b/README.md
@@ -28,19 +28,12 @@ Tally will be
 
 Try this.
 
-In some Linux distributions such as Ubuntu 20.04, you need to explicitly
-tell npm where your `python3` executable is located:
-
-```sh
-$ npm config set python /usr/bin/python3
-```
-
 ```sh
 $ nvm use
 $ nvm install
 $ npm install -g yarn # if you don't have yarn globally installed
 $ yarn install # install all dependencies; rerun with --ignore-scripts if
-               # script node-gyp failures prevent the install from completing
+               # scrypt node-gyp failures prevent the install from completing
 $ yarn start # start a continuous webpack build that will auto-update with changes
 ```
 
@@ -63,6 +56,16 @@ to only rebuild the Firefox extension on change:
 $ yarn start --config-name firefox
 # On change, rebuild the firefox and brave extensions but not others.
 $ yarn start --config-name firefox --config-name brave
+```
+
+### Note for some Linux distributions
+
+In some Linux distributions such as Ubuntu 20.04, you need to explicitly
+tell npm where your `python3` executable is located before running the above
+commands successfully:
+
+```sh
+$ npm config set python /usr/bin/python3
 ```
 
 ## Package Structure, Build Structure, and Threat Model

--- a/README.md
+++ b/README.md
@@ -28,11 +28,19 @@ Tally will be
 
 Try this.
 
+In some Linux distributions such as Ubuntu 20.04, you need to explicitly
+tell npm where your `python3` executable is located:
+
+```sh
+$ npm config set python /usr/bin/python3
+```
+
 ```sh
 $ nvm use
+$ nvm install
 $ npm install -g yarn # if you don't have yarn globally installed
 $ yarn install # install all dependencies; rerun with --ignore-scripts if
-               # scrypt node-gyp failures prevent the install from completing
+               # script node-gyp failures prevent the install from completing
 $ yarn start # start a continuous webpack build that will auto-update with changes
 ```
 
@@ -114,6 +122,13 @@ install:
 Before committing code to this repository or a fork/branch that you intend to
 submit for inclusion, please make sure you've installed the pre-commit hooks
 by running `pre-commit install`. The macOS setup script does this for you.
+
+### Commit signing
+
+Commits on the Tally repository are all required to be signed.
+No PR will be merged if it has unsigned commits. See the
+[GitHub documentation on commit signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+to get it set up.
 
 ### Releasing a version
 

--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -126,3 +126,14 @@ export const numberTo32BytesHex = (value: string, decimals: number): string => {
 export const isMaxUint256 = (amount: BigNumber | bigint | string): boolean => {
   return ethers.BigNumber.from(amount).eq(ethers.constants.MaxUint256)
 }
+
+/**
+ * Converts a string of hexidecimals bytes to ascii text
+ */
+export const hexToAscii = (hex_: string) => {
+  let hex = hex_.toString();//force conversion
+  var str = '';
+  for (var i = 0; i < hex.length; i += 2)
+    str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+  return str.replace('\x00', ''); 
+}

--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -131,9 +131,9 @@ export const isMaxUint256 = (amount: BigNumber | bigint | string): boolean => {
  * Converts a string of hexidecimals bytes to ascii text
  */
 export const hexToAscii = (hex_: string) => {
-  let hex = hex_.toString();//force conversion
-  var str = '';
-  for (var i = 0; i < hex.length; i += 2)
-    str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
-  return str.replace('\x00', ''); 
+  const hex = hex_.toString() // force conversion
+  let str = ""
+  for (let i = 0; i < hex.length; i += 2)
+    str += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
+  return str.replace("\x00", "")
 }

--- a/background/main.ts
+++ b/background/main.ts
@@ -662,14 +662,14 @@ export default class Main extends BaseService<never> {
     signingSliceEmitter.on(
       "requestSignData",
       async ({
-        signingData,
+        rawSigningData,
         account,
       }: {
-        signingData: EIP191Data
+        rawSigningData: string,
         account: HexString
       }) => {
         const signedData = await this.keyringService.personalSign({
-          signingData,
+          signingData: rawSigningData,
           account,
         })
         this.store.dispatch(signedDataAction(signedData))

--- a/background/main.ts
+++ b/background/main.ts
@@ -665,7 +665,7 @@ export default class Main extends BaseService<never> {
         rawSigningData,
         account,
       }: {
-        rawSigningData: string,
+        rawSigningData: string
         account: HexString
       }) => {
         const signedData = await this.keyringService.personalSign({

--- a/background/main.ts
+++ b/background/main.ts
@@ -271,10 +271,9 @@ export default class Main extends BaseService<never> {
       ? (Promise.resolve(null) as unknown as Promise<LedgerService>)
       : LedgerService.create()
 
-    // const signingService = HIDE_IMPORT_LEDGER
-      // ? (Promise.resolve(null) as unknown as Promise<SigningService>)
-      // : SigningService.create(keyringService, ledgerService, chainService)
-    const signingService = SigningService.create(keyringService, ledgerService, chainService);
+    const signingService = HIDE_IMPORT_LEDGER
+      ? (Promise.resolve(null) as unknown as Promise<SigningService>)
+      : SigningService.create(keyringService, ledgerService, chainService)
 
     let savedReduxState = {}
     // Setting READ_REDUX_CACHE to false will start the extension with an empty
@@ -386,11 +385,9 @@ export default class Main extends BaseService<never> {
         handler: () => this.store.dispatch(initializationLoadingTimeHitLimit()),
       },
     })
-  
+
     // Start up the redux store and set it up for proxying.
     this.store = initializeStore(savedReduxState, this)
-
-    console.log('store', this.store)
 
     wrapStore(this.store, {
       serializer: encodeJSON,
@@ -668,7 +665,7 @@ export default class Main extends BaseService<never> {
         signingData,
         account,
       }: {
-        signingData: EIP191Data, 
+        signingData: EIP191Data
         account: HexString
       }) => {
         const signedData = await this.keyringService.personalSign({

--- a/background/main.ts
+++ b/background/main.ts
@@ -792,10 +792,14 @@ export default class Main extends BaseService<never> {
     })
 
     keyringSliceEmitter.on("deriveAddress", async (keyringID) => {
-      await this.signingService.deriveAddress({
-        type: "keyring",
-        accountID: keyringID,
-      })
+      if (HIDE_IMPORT_LEDGER) {
+        await this.keyringService.deriveAddress(keyringID)
+      } else {
+        await this.signingService.deriveAddress({
+          type: "keyring",
+          accountID: keyringID,
+        })
+      }
     })
 
     keyringSliceEmitter.on("generateNewKeyring", async () => {

--- a/background/package.json
+++ b/background/package.json
@@ -54,6 +54,7 @@
     "ethereumjs-util": "^7.1.0",
     "ethers": "^5.5.1",
     "node-fetch": "^2.6.1",
+    "siwe": "^1.1.0",
     "util": "^0.12.4",
     "webextension-polyfill": "^0.8.0"
   },

--- a/background/redux-slices/0x-swap.ts
+++ b/background/redux-slices/0x-swap.ts
@@ -111,7 +111,6 @@ const gatedParameters =
     ? {
         affiliateAddress: COMMUNITY_MULTISIG_ADDRESS,
         feeRecipient: COMMUNITY_MULTISIG_ADDRESS,
-        // includedSources: "RFQT", FIXME This seems to limit available liquidity considerably
         buyTokenPercentageFee: SWAP_FEE,
       }
     : {}

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -70,7 +70,7 @@ export type CompleteAssetAmount<
   T extends AnyAssetAmount<E> = AnyAssetAmount<E>
 > = T & AssetMainCurrencyAmount & AssetDecimalAmount
 
-export type SmartContractFungibleCompleteAssetAmount = CompleteAssetAmount<
+export type CompleteSmartContractFungibleAssetAmount = CompleteAssetAmount<
   SmartContractFungibleAsset,
   AnyAssetAmount<SmartContractFungibleAsset>
 >

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -2,7 +2,7 @@ import { createSlice } from "@reduxjs/toolkit"
 import { createBackgroundAsyncThunk } from "./utils"
 import { AccountBalance, AddressNetwork, NameNetwork } from "../accounts"
 import { AnyEVMBlock, Network } from "../networks"
-import { AnyAsset, AnyAssetAmount } from "../assets"
+import { AnyAsset, AnyAssetAmount, SmartContractFungibleAsset } from "../assets"
 import {
   AssetMainCurrencyAmount,
   AssetDecimalAmount,
@@ -69,6 +69,11 @@ export type CompleteAssetAmount<
   E extends AnyAsset = AnyAsset,
   T extends AnyAssetAmount<E> = AnyAssetAmount<E>
 > = T & AssetMainCurrencyAmount & AssetDecimalAmount
+
+export type SmartContractFungibleCompleteAssetAmount = CompleteAssetAmount<
+  SmartContractFungibleAsset,
+  AnyAssetAmount<SmartContractFungibleAsset>
+>
 
 export const initialState = {
   accountsData: {},

--- a/background/redux-slices/index.ts
+++ b/background/redux-slices/index.ts
@@ -23,8 +23,8 @@ const mainReducer = combineReducers({
   transactionConstruction: transactionConstructionReducer,
   ui: uiReducer,
   dappPermission: dappPermissionReducer,
-  ...(HIDE_IMPORT_LEDGER ? {} : { ledger: ledgerReducer }),
   signing: signingReducer,
+  ...(HIDE_IMPORT_LEDGER ? {} : { ledger: ledgerReducer }),
   ...(HIDE_EARN_PAGE ? {} : { earn: earnReducer }),
 })
 

--- a/background/redux-slices/signing.ts
+++ b/background/redux-slices/signing.ts
@@ -122,14 +122,12 @@ export const {
 export default signingSlice.reducer
 
 export const selectTypedData = createSelector(
-  (state: { signing: { typedDataRequest: SignTypedDataRequest } }) =>
-    state.signing.typedDataRequest,
+  (state: { signing: SigningState }) => state.signing.typedDataRequest,
   (signTypes) => signTypes
 )
 
 export const selectSigningData = createSelector(
-  (state: { signing: { signDataRequest: SignDataRequest } }) =>
-    state.signing.signDataRequest,
+  (state: { signing: SigningState }) => state.signing.signDataRequest,
   (signTypes) => signTypes
 )
 

--- a/background/redux-slices/signing.ts
+++ b/background/redux-slices/signing.ts
@@ -2,6 +2,16 @@ import { createSelector, createSlice } from "@reduxjs/toolkit"
 import Emittery from "emittery"
 import { EIP191Data, EIP712TypedData, HexString } from "../types"
 import { createBackgroundAsyncThunk } from "./utils"
+import { SiweMessage } from 'siwe';
+
+
+export enum SignDataMessageType {
+  EIP191 = 0,
+  EIP4361 = 1,
+}
+
+// can add more types to this in the future
+export type ExpectedSigningData = EIP191Data | EIP4361Data;
 
 export type Events = {
   requestSignTypedData: {
@@ -9,7 +19,9 @@ export type Events = {
     account: HexString
   }
   requestSignData: {
-    signingData: EIP191Data
+    signingData: ExpectedSigningData
+    messageType: SignDataMessageType
+    rawSigningData: string 
     account: HexString
   }
   signatureRejected: never
@@ -49,9 +61,22 @@ export type SignTypedDataRequest = {
   typedData: EIP712TypedData
 }
 
+// spec found https://eips.ethereum.org/EIPS/eip-4361
+export interface EIP4361Data {
+  domain: string,
+  address: string
+  version: string;
+  chainId: number;
+  nonce: string;
+  expiration?: string;
+  statement?: string
+}
+
 export type SignDataRequest = {
   account: string
-  signingData: EIP191Data
+  rawSigningData: string
+  signingData: ExpectedSigningData
+  messageType: SignDataMessageType
 }
 
 export const signTypedData = createBackgroundAsyncThunk(
@@ -68,13 +93,70 @@ export const signTypedData = createBackgroundAsyncThunk(
 export const signData = createBackgroundAsyncThunk(
   "signing/signData",
   async (data: SignDataRequest) => {
-    const { account, signingData } = data
+    const { account, signingData, rawSigningData, messageType } = data
     await signingSliceEmitter.emit("requestSignData", {
+      rawSigningData,
       signingData,
       account,
+      messageType
     })
   }
 )
+
+const checkEIP4361: (message: string) => EIP4361Data | undefined = (message) => {
+  try {
+    const siweMessage = new SiweMessage(message);
+    console.log('message', siweMessage);
+    if (siweMessage.domain) {
+      return ({
+        domain: siweMessage.domain,
+        address: siweMessage.address, 
+        statement:siweMessage.statement, 
+        version: siweMessage.version,
+        chainId: siweMessage.chainId,
+        expiration: siweMessage.expirationTime,
+        nonce: siweMessage.domain
+    })
+    }
+  } catch(err) {
+    console.error(err)
+  }
+
+  return undefined;
+}
+
+
+/**
+ * Takes a string and parses the string into a ExpectedSigningData Type
+ *
+ * EIP4361 standard can be found https://eips.ethereum.org/EIPS/eip-4361
+ */
+export const parseSigningData: (signingData: string) => {
+  data: ExpectedSigningData,
+  type: SignDataMessageType
+} = (signingData) => {
+  let data;
+  data = checkEIP4361(signingData)
+  console.log('parsed lines', data)
+  if (!!data) {
+    return {
+      data,
+      type: SignDataMessageType.EIP4361
+    }
+  }
+
+  // data = checkOtherType(lines)
+  // if (!!data) {
+    // return data
+  //}
+
+  // add additional checks for any other types to add in the future
+  return {
+    data: signingData,
+    type: SignDataMessageType.EIP191
+  }
+}
+
 
 const signingSlice = createSlice({
   name: "signing",

--- a/background/redux-slices/signing.ts
+++ b/background/redux-slices/signing.ts
@@ -2,7 +2,6 @@ import { createSelector, createSlice } from "@reduxjs/toolkit"
 import Emittery from "emittery"
 import { EIP191Data, EIP712TypedData, HexString } from "../types"
 import { createBackgroundAsyncThunk } from "./utils"
-import { RootState } from "."
 
 export type Events = {
   requestSignTypedData: {
@@ -123,12 +122,14 @@ export const {
 export default signingSlice.reducer
 
 export const selectTypedData = createSelector(
-  (state: RootState) => state.signing.typedDataRequest,
+  (state: { signing: { typedDataRequest: SignTypedDataRequest } }) =>
+    state.signing.typedDataRequest,
   (signTypes) => signTypes
 )
 
 export const selectSigningData = createSelector(
-  (state: RootState) => state.signing.signDataRequest,
+  (state: { signing: { signDataRequest: SignDataRequest } }) =>
+    state.signing.signDataRequest,
   (signTypes) => signTypes
 )
 

--- a/background/redux-slices/signing.ts
+++ b/background/redux-slices/signing.ts
@@ -114,7 +114,7 @@ const checkEIP4361: (message: string) => EIP4361Data | undefined = (
       version: siweMessage.version,
       chainId: siweMessage.chainId,
       expiration: siweMessage.expirationTime,
-      nonce: siweMessage.domain,
+      nonce: siweMessage.nonce,
     }
   } catch (err) {
     // console.error(err)

--- a/background/redux-slices/signing.ts
+++ b/background/redux-slices/signing.ts
@@ -10,7 +10,7 @@ export type Events = {
     account: HexString
   }
   requestSignData: {
-    signingData: EIP191Data 
+    signingData: EIP191Data
     account: HexString
   }
   signatureRejected: never
@@ -35,7 +35,7 @@ export const initialState: SigningState = {
   signedTypedData: undefined,
 
   signedData: undefined,
-  signDataRequest: undefined
+  signDataRequest: undefined,
 }
 
 export type EIP712DomainType = {
@@ -93,32 +93,32 @@ const signingSlice = createSlice({
       ...state,
       typedDataRequest: payload,
     }),
-    signDataRequest: (
-      state,
-      { payload }: { payload: SignDataRequest }
-    ) => {
-      return ({
-      ...state,
-      signDataRequest: payload
-    })},
-    signedData: (
-      state,
-      { payload }: { payload: string }
-    ) => ({
+    signDataRequest: (state, { payload }: { payload: SignDataRequest }) => {
+      return {
+        ...state,
+        signDataRequest: payload,
+      }
+    },
+    signedData: (state, { payload }: { payload: string }) => ({
       ...state,
       signedData: payload,
-      signDataRequest: undefined  
+      signDataRequest: undefined,
     }),
     clearSigningState: (state) => ({
       ...state,
       typedDataRequest: undefined,
-      signDataRequest: undefined
+      signDataRequest: undefined,
     }),
   },
 })
 
-export const { signedTypedData, typedDataRequest, signedData, signDataRequest, clearSigningState } =
-  signingSlice.actions
+export const {
+  signedTypedData,
+  typedDataRequest,
+  signedData,
+  signDataRequest,
+  clearSigningState,
+} = signingSlice.actions
 
 export default signingSlice.reducer
 

--- a/background/redux-slices/signing.ts
+++ b/background/redux-slices/signing.ts
@@ -1,9 +1,8 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit"
 import Emittery from "emittery"
+import { SiweMessage } from "siwe"
 import { EIP191Data, EIP712TypedData, HexString } from "../types"
 import { createBackgroundAsyncThunk } from "./utils"
-import { SiweMessage } from 'siwe';
-
 
 export enum SignDataMessageType {
   EIP191 = 0,
@@ -11,7 +10,7 @@ export enum SignDataMessageType {
 }
 
 // can add more types to this in the future
-export type ExpectedSigningData = EIP191Data | EIP4361Data;
+export type ExpectedSigningData = EIP191Data | EIP4361Data
 
 export type Events = {
   requestSignTypedData: {
@@ -21,7 +20,7 @@ export type Events = {
   requestSignData: {
     signingData: ExpectedSigningData
     messageType: SignDataMessageType
-    rawSigningData: string 
+    rawSigningData: string
     account: HexString
   }
   signatureRejected: never
@@ -63,12 +62,12 @@ export type SignTypedDataRequest = {
 
 // spec found https://eips.ethereum.org/EIPS/eip-4361
 export interface EIP4361Data {
-  domain: string,
+  domain: string
   address: string
-  version: string;
-  chainId: number;
-  nonce: string;
-  expiration?: string;
+  version: string
+  chainId: number
+  nonce: string
+  expiration?: string
   statement?: string
 }
 
@@ -98,33 +97,31 @@ export const signData = createBackgroundAsyncThunk(
       rawSigningData,
       signingData,
       account,
-      messageType
+      messageType,
     })
   }
 )
 
-const checkEIP4361: (message: string) => EIP4361Data | undefined = (message) => {
+const checkEIP4361: (message: string) => EIP4361Data | undefined = (
+  message
+) => {
   try {
-    const siweMessage = new SiweMessage(message);
-    console.log('message', siweMessage);
-    if (siweMessage.domain) {
-      return ({
-        domain: siweMessage.domain,
-        address: siweMessage.address, 
-        statement:siweMessage.statement, 
-        version: siweMessage.version,
-        chainId: siweMessage.chainId,
-        expiration: siweMessage.expirationTime,
-        nonce: siweMessage.domain
-    })
+    const siweMessage = new SiweMessage(message)
+    return {
+      domain: siweMessage.domain,
+      address: siweMessage.address,
+      statement: siweMessage.statement,
+      version: siweMessage.version,
+      chainId: siweMessage.chainId,
+      expiration: siweMessage.expirationTime,
+      nonce: siweMessage.domain,
     }
-  } catch(err) {
-    console.error(err)
+  } catch (err) {
+    // console.error(err)
   }
 
-  return undefined;
+  return undefined
 }
-
 
 /**
  * Takes a string and parses the string into a ExpectedSigningData Type
@@ -132,31 +129,28 @@ const checkEIP4361: (message: string) => EIP4361Data | undefined = (message) => 
  * EIP4361 standard can be found https://eips.ethereum.org/EIPS/eip-4361
  */
 export const parseSigningData: (signingData: string) => {
-  data: ExpectedSigningData,
+  data: ExpectedSigningData
   type: SignDataMessageType
 } = (signingData) => {
-  let data;
-  data = checkEIP4361(signingData)
-  console.log('parsed lines', data)
-  if (!!data) {
+  const data = checkEIP4361(signingData)
+  if (data) {
     return {
       data,
-      type: SignDataMessageType.EIP4361
+      type: SignDataMessageType.EIP4361,
     }
   }
 
   // data = checkOtherType(lines)
   // if (!!data) {
-    // return data
-  //}
+  // return data
+  // }
 
   // add additional checks for any other types to add in the future
   return {
     data: signingData,
-    type: SignDataMessageType.EIP191
+    type: SignDataMessageType.EIP191,
   }
 }
-
 
 const signingSlice = createSlice({
   name: "signing",

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -143,7 +143,7 @@ const transactionSlice = createSlice({
       estimatedFeesPerGas: state.estimatedFeesPerGas,
       lastGasEstimatesRefreshed: state.lastGasEstimatesRefreshed,
       status: payload,
-      feeTypeSelected: NetworkFeeTypeChosen.Regular,
+      feeTypeSelected: state.feeTypeSelected ?? NetworkFeeTypeChosen.Regular,
       broadcastOnSign: false,
       signedTransaction: undefined,
     }),

--- a/background/services/chain/utils.ts
+++ b/background/services/chain/utils.ts
@@ -150,9 +150,11 @@ export function enrichTransactionWithReceipt(
   receipt: EthersTransactionReceipt
 ): ConfirmedEVMTransaction {
   const gasUsed = receipt.gasUsed.toBigInt()
+
   return {
     ...transaction,
     gasUsed,
+    gasPrice: receipt.effectiveGasPrice.toBigInt(),
     status:
       receipt.status ??
       // Pre-Byzantium transactions require a guesswork approach or an

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -21,8 +21,9 @@ import { internalProviderPort } from "../../redux-slices/utils/contract-utils"
 import {
   SignTypedDataRequest,
   SignDataRequest,
+  parseSigningData,
 } from "../../redux-slices/signing"
-import { getEthereumNetwork } from "../../lib/utils"
+import { getEthereumNetwork, hexToAscii } from "../../lib/utils"
 
 // A type representing the transaction requests that come in over JSON-RPC
 // requests like eth_sendTransaction and eth_signTransaction. These are very
@@ -183,9 +184,13 @@ export default class InternalEthereumProviderService extends BaseService<Events>
         )
       case "eth_sign": // --- important wallet methods ---
       case "personal_sign":
+        const signingData_ = hexToAscii(params[0] as string);
+        const parsedInfo = parseSigningData(signingData_);
         return this.signData({
           account: params[1],
-          signingData: params[0],
+          signingData: parsedInfo.data,
+          messageType: parsedInfo.type,
+          rawSigningData: signingData_
         } as SignDataRequest)
       case "metamask_getProviderState": // --- important MM only methods ---
       case "metamask_sendDomainMetadata":

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -184,13 +184,15 @@ export default class InternalEthereumProviderService extends BaseService<Events>
         )
       case "eth_sign": // --- important wallet methods ---
       case "personal_sign":
-        const signingData_ = hexToAscii(params[0] as string);
-        const parsedInfo = parseSigningData(signingData_);
+        // eslint-disable-next-line no-case-declarations
+        const asciiSigningData = hexToAscii(params[0] as string)
+        // eslint-disable-next-line no-case-declarations
+        const parsedInfo = parseSigningData(asciiSigningData)
         return this.signData({
           account: params[1],
           signingData: parsedInfo.data,
           messageType: parsedInfo.type,
-          rawSigningData: signingData_
+          rawSigningData: asciiSigningData,
         } as SignDataRequest)
       case "metamask_getProviderState": // --- important MM only methods ---
       case "metamask_sendDomainMetadata":

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -18,7 +18,10 @@ import {
 } from "../chain/utils"
 import PreferenceService from "../preferences"
 import { internalProviderPort } from "../../redux-slices/utils/contract-utils"
-import { SignTypedDataRequest, SignDataRequest } from "../../redux-slices/signing"
+import {
+  SignTypedDataRequest,
+  SignDataRequest,
+} from "../../redux-slices/signing"
 import { getEthereumNetwork } from "../../lib/utils"
 
 // A type representing the transaction requests that come in over JSON-RPC
@@ -183,7 +186,7 @@ export default class InternalEthereumProviderService extends BaseService<Events>
         return this.signData({
           account: params[1],
           signingData: params[0],
-      } as SignDataRequest)
+        } as SignDataRequest)
       case "metamask_getProviderState": // --- important MM only methods ---
       case "metamask_sendDomainMetadata":
       case "wallet_requestPermissions":

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -11,7 +11,13 @@ import {
   encryptVault,
   SaltedKey,
 } from "./encryption"
-import { HexString, KeyringTypes, EIP191Data, EIP712TypedData, UNIXTime } from "../../types"
+import {
+  HexString,
+  KeyringTypes,
+  EIP191Data,
+  EIP712TypedData,
+  UNIXTime,
+} from "../../types"
 import { EIP1559TransactionRequest, SignedEVMTransaction } from "../../networks"
 import BaseService from "../base"
 import { ETH, MINUTE } from "../../constants"
@@ -445,7 +451,6 @@ export default class KeyringService extends BaseService<Events> {
     }
   }
 
-
   /**
    * Sign data based on EIP-191 with the usage of personal_sign method,
    * more information about the EIP can be found at https://eips.ethereum.org/EIPS/eip-191
@@ -465,10 +470,7 @@ export default class KeyringService extends BaseService<Events> {
     // find the keyring using a linear search
     const keyring = await this.#findKeyring(account)
     try {
-      const signature = await keyring.signMessage(
-        account,
-        signingData
-      )
+      const signature = await keyring.signMessage(account, signingData)
       this.emitter.emit("signedData", signature)
       return signature
     } catch (error) {

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -447,10 +447,10 @@ export default class KeyringService extends BaseService<Events> {
 
 
   /**
-   * Sign typed data based on EIP-712 with the usage of eth_signTypedData_v4 method,
-   * more information about the EIP can be found at https://eips.ethereum.org/EIPS/eip-712
+   * Sign data based on EIP-191 with the usage of personal_sign method,
+   * more information about the EIP can be found at https://eips.ethereum.org/EIPS/eip-191
    *
-   * @param typedData - the data to be signed
+   * @param signingData - the data to be signed
    * @param account - signers account address
    */
 
@@ -462,11 +462,8 @@ export default class KeyringService extends BaseService<Events> {
     account: HexString
   }): Promise<string> {
     this.requireUnlocked()
-    // const { domain, types, message } = typedData
     // find the keyring using a linear search
     const keyring = await this.#findKeyring(account)
-    // When signing we should not include EIP712Domain type
-    // const { EIP712Domain, ...typesForSigning } = types
     try {
       const signature = await keyring.signMessage(
         account,

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -299,6 +299,8 @@ export default class KeyringService extends BaseService<Events> {
    * used outside the extension.
    */
   getKeyrings(): Keyring[] {
+    this.requireUnlocked()
+
     return this.#keyrings.map((kr) => ({
       // TODO this type is meanlingless from the library's perspective.
       // Reconsider, or explicitly track which keyrings have been generated vs
@@ -449,8 +451,12 @@ export default class KeyringService extends BaseService<Events> {
   // //////////////////
 
   private emitKeyrings() {
-    const keyrings = this.getKeyrings()
-    this.emitter.emit("keyrings", keyrings)
+    if (this.locked()) {
+      this.emitter.emit("keyrings", [])
+    } else {
+      const keyrings = this.getKeyrings()
+      this.emitter.emit("keyrings", keyrings)
+    }
   }
 
   /**

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -131,7 +131,7 @@ export default class KeyringService extends BaseService<Events> {
     password: string,
     ignoreExistingVaults = false
   ): Promise<boolean> {
-    if (this.locked() === false) {
+    if (!this.locked()) {
       throw new Error("KeyringService is already unlocked!")
     }
 

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -291,6 +291,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
     params: RPCRequest["params"]
   ): Promise<unknown> {
     try {
+      let walletAddress, signDataPopupPromise;
       switch (method) {
         case "eth_requestAccounts":
         case "eth_accounts":
@@ -301,9 +302,9 @@ export default class ProviderBridgeService extends BaseService<Events> {
         case "eth_signTypedData_v4":
           // When its signTypedData the params[0] should be the walletAddress
           // eslint-disable-next-line no-case-declarations
-          const walletAddress = params[0] as HexString
+          walletAddress = params[0] as HexString
           // eslint-disable-next-line no-case-declarations
-          const signDataPopupPromise = ProviderBridgeService.showExtensionPopup(
+          signDataPopupPromise = ProviderBridgeService.showExtensionPopup(
             AllowedQueryParamPage.signData
           )
           if (
@@ -316,7 +317,24 @@ export default class ProviderBridgeService extends BaseService<Events> {
             )
           }
           throw new EIP1193Error(EIP1193_ERROR_CODES.unauthorized)
-
+        case "eth_sign":
+        case "personal_sign":
+          // eslint-disable-next-line no-case-declarations
+          walletAddress = params[1] as HexString
+          // eslint-disable-next-line no-case-declarations
+          signDataPopupPromise = ProviderBridgeService.showExtensionPopup(
+            AllowedQueryParamPage.personalSignData
+          )
+          if (
+            sameEVMAddress(walletAddress, enablingPermission.accountAddress)
+          ) {
+            return await this.routeSafeRequest(
+              method,
+              params,
+              signDataPopupPromise
+            )
+          }
+          throw new EIP1193Error(EIP1193_ERROR_CODES.unauthorized)
         case "eth_signTransaction":
         case "eth_sendTransaction":
           // We are monsters and aren't breaking a method out quite yet.

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -291,7 +291,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
     params: RPCRequest["params"]
   ): Promise<unknown> {
     try {
-      let walletAddress, signDataPopupPromise;
+      let walletAddress
+      let signDataPopupPromise
       switch (method) {
         case "eth_requestAccounts":
         case "eth_accounts":

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -322,6 +322,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
         case "personal_sign":
           // eslint-disable-next-line no-case-declarations
           walletAddress = params[1] as HexString
+
           // eslint-disable-next-line no-case-declarations
           signDataPopupPromise = ProviderBridgeService.showExtensionPopup(
             AllowedQueryParamPage.personalSignData

--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -10,8 +10,8 @@ import ChainService from "../chain"
 import { SigningMethod } from "../../redux-slices/signing"
 
 type ErrorResponse = {
-    type: "error"
-    reason: "userRejected" | "genericError"
+  type: "error"
+  reason: "userRejected" | "genericError"
 }
 
 export type SignatureResponse =
@@ -141,7 +141,7 @@ export default class SigningService extends BaseService<Events> {
             this.emitter.emit("signingResponse", {
               type: "error",
               reason: "userRejected",
-            }) 
+            })
             throw err
           default:
             break
@@ -174,17 +174,24 @@ export default class SigningService extends BaseService<Events> {
     throw new Error("Unimplemented")
   }
 
-  async signData(address: string, message: string, signingMethod: SigningMethod): Promise<string> {
+  async signData(
+    address: string,
+    message: string,
+    signingMethod: SigningMethod
+  ): Promise<string> {
     this.signData = this.signData.bind(this)
     try {
-      let signedMsg;
+      let signedMsg
       switch (signingMethod.type) {
         case "ledger":
           signedMsg = await this.ledgerService.signMessage(address, message)
-          break;
+          break
         case "keyring":
-          signedMsg = await this.keyringService.personalSign({ signingData: message, account: address })
-          break;
+          signedMsg = await this.keyringService.personalSign({
+            signingData: message,
+            account: address,
+          })
+          break
         default:
           throw new Error(`Unreachable!`)
       }
@@ -193,7 +200,7 @@ export default class SigningService extends BaseService<Events> {
         type: "success",
         signedMsg,
       })
-      return signedMsg;
+      return signedMsg
     } catch (err) {
       if (err instanceof TransportStatusError) {
         const transportError = err as Error & { statusCode: number }
@@ -215,6 +222,6 @@ export default class SigningService extends BaseService<Events> {
       })
 
       throw err
-    } 
+    }
   }
 }

--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -9,18 +9,28 @@ import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
 import ChainService from "../chain"
 import { SigningMethod } from "../../redux-slices/signing"
 
+type ErrorResponse = {
+    type: "error"
+    reason: "userRejected" | "genericError"
+}
+
 export type SignatureResponse =
   | {
       type: "success"
       signedTx: SignedEVMTransaction
     }
+  | ErrorResponse
+
+export type PersonalSignatureResponse =
   | {
-      type: "error"
-      reason: "userRejected" | "genericError"
+      type: "success"
+      signedMsg: string
     }
+  | ErrorResponse
 
 type Events = ServiceLifecycleEvents & {
   signingResponse: SignatureResponse
+  personalSigningResponse: PersonalSignatureResponse
 }
 
 type SignerType = "keyring" | HardwareSignerType
@@ -131,7 +141,7 @@ export default class SigningService extends BaseService<Events> {
             this.emitter.emit("signingResponse", {
               type: "error",
               reason: "userRejected",
-            })
+            }) 
             throw err
           default:
             break
@@ -164,9 +174,46 @@ export default class SigningService extends BaseService<Events> {
     throw new Error("Unimplemented")
   }
 
-  async signMessage(address: string, message: string): Promise<string> {
-    this.signMessage = this.signMessage.bind(this)
+  async signMessage(address: string, message: string, signingMethod: SigningMethod): Promise<string> {
+    try {
+      let signedMsg;
+      switch (signingMethod.type) {
+        case "ledger":
+          signedMsg = await this.ledgerService.signMessage(address, message)
+          break;
+        case "keyring":
+          signedMsg = await this.keyringService.personalSign({ signingData: message, account: address })
+          break;
+        default:
+          throw new Error(`Unreachable!`)
+      }
 
-    throw new Error("Unimplemented")
+      this.emitter.emit("personalSigningResponse", {
+        type: "success",
+        signedMsg,
+      })
+      return signedMsg;
+    } catch (err) {
+      if (err instanceof TransportStatusError) {
+        const transportError = err as Error & { statusCode: number }
+        switch (transportError.statusCode) {
+          case StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED:
+            this.emitter.emit("personalSigningResponse", {
+              type: "error",
+              reason: "userRejected",
+            })
+            throw err
+          default:
+            break
+        }
+      }
+
+      this.emitter.emit("personalSigningResponse", {
+        type: "error",
+        reason: "genericError",
+      })
+
+      throw err
+    } 
   }
 }

--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -174,7 +174,8 @@ export default class SigningService extends BaseService<Events> {
     throw new Error("Unimplemented")
   }
 
-  async signMessage(address: string, message: string, signingMethod: SigningMethod): Promise<string> {
+  async signData(address: string, message: string, signingMethod: SigningMethod): Promise<string> {
+    this.signData = this.signData.bind(this)
     try {
       let signedMsg;
       switch (signingMethod.type) {

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -196,7 +196,7 @@ describe("KeyringService when initialized", () => {
     })
   })
 
-  it.only("will derive a new address", async () => {
+  it("will derive a new address", async () => {
     const [
       {
         id,
@@ -334,7 +334,7 @@ describe("KeyringService when saving keyrings", () => {
     })
   })
 
-  it.only("loads encrypted data at instantiation time", async () => {
+  it("loads encrypted data at instantiation time", async () => {
     localStorage = {
       tallyVaults: {
         version: 1,

--- a/background/types.ts
+++ b/background/types.ts
@@ -66,3 +66,5 @@ export type EIP712TypedData = {
   message: Record<string, unknown>
   primaryType: string
 }
+
+export type EIP191Data = string

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "dotenv-defaults": "^2.0.2",
     "dotenv-webpack": "^7.0.3",
     "eslint": "^7.28.0",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^14.0.0",

--- a/provider-bridge-shared/runtime-typechecks.ts
+++ b/provider-bridge-shared/runtime-typechecks.ts
@@ -65,7 +65,7 @@ export const AllowedQueryParamPage = {
   signTransaction: "/signTransaction",
   dappPermission: "/dappPermission",
   signData: "/signData",
-  personalSignData: "/personalSign"
+  personalSignData: "/personalSign",
 } as const
 
 export type AllowedQueryParamPageType =

--- a/provider-bridge-shared/runtime-typechecks.ts
+++ b/provider-bridge-shared/runtime-typechecks.ts
@@ -65,6 +65,7 @@ export const AllowedQueryParamPage = {
   signTransaction: "/signTransaction",
   dappPermission: "/dappPermission",
   signData: "/signData",
+  personalSignData: "/personalSign"
 } as const
 
 export type AllowedQueryParamPageType =

--- a/ui/components/Shared/SharedSlideUpMenu.tsx
+++ b/ui/components/Shared/SharedSlideUpMenu.tsx
@@ -1,6 +1,6 @@
+import React, { ReactElement, CSSProperties, useRef } from "react"
 import classNames from "classnames"
-import React, { ReactElement, useState, useEffect, CSSProperties } from "react"
-import { useDelayContentChange } from "../../hooks"
+import { useDelayContentChange, useOnClickOutside } from "../../hooks"
 
 export type SharedSlideUpMenuSize =
   | "auto"
@@ -17,7 +17,6 @@ interface Props {
   children: React.ReactNode
   customSize?: string
   size: SharedSlideUpMenuSize
-  showOverlay?: boolean
   alwaysRenderChildren?: boolean
 }
 
@@ -30,15 +29,12 @@ const menuHeights: Record<SharedSlideUpMenuSize, string | null> = {
 }
 
 export default function SharedSlideUpMenu(props: Props): ReactElement {
-  const {
-    isOpen,
-    close,
-    size,
-    children,
-    customSize,
-    showOverlay,
-    alwaysRenderChildren,
-  } = props
+  const { isOpen, close, size, children, customSize, alwaysRenderChildren } =
+    props
+
+  const ref = useRef(null)
+
+  useOnClickOutside(ref, close)
 
   // Continue showing children during the close transition.
   const visibleChildren = isOpen || alwaysRenderChildren ? children : <></>
@@ -52,15 +48,14 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
 
   return (
     <>
-      {showOverlay && (
-        <div className={classNames("overlay", { closed: !isOpen })} />
-      )}
+      <div className={classNames("overlay", { closed: !isOpen })} />
       <div
         className={classNames("slide_up_menu", {
           large: size === "large",
           closed: !isOpen,
         })}
         style={{ "--menu-height": menuHeight } as CSSProperties}
+        ref={isOpen ? ref : null}
       >
         <button
           type="button"
@@ -97,9 +92,10 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
             right: 0;
             bottom: 0;
             top: 0;
+            cursor: pointer;
             z-index: 998;
-            background: var(--hunter-green);
-            opacity: 0.8;
+            background: var(--green-120);
+            opacity: 0.7;
             transition: opacity cubic-bezier(0.19, 1, 0.22, 1) 0.445s,
               visiblity 0.445s;
           }

--- a/ui/components/Shared/SharedSlideUpMenu.tsx
+++ b/ui/components/Shared/SharedSlideUpMenu.tsx
@@ -32,9 +32,9 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
   const { isOpen, close, size, children, customSize, alwaysRenderChildren } =
     props
 
-  const ref = useRef(null)
+  const slideUpMenuRef = useRef(null)
 
-  useOnClickOutside(ref, close)
+  useOnClickOutside(slideUpMenuRef, close)
 
   // Continue showing children during the close transition.
   const visibleChildren = isOpen || alwaysRenderChildren ? children : <></>
@@ -55,7 +55,7 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
           closed: !isOpen,
         })}
         style={{ "--menu-height": menuHeight } as CSSProperties}
-        ref={isOpen ? ref : null}
+        ref={isOpen ? slideUpMenuRef : null}
       >
         <button
           type="button"

--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -84,7 +84,6 @@ export default function SignTransactionContainer({
         close={() => {
           setSlideUpOpen(false)
         }}
-        showOverlay
         alwaysRenderChildren
         size="auto"
       >

--- a/ui/components/Swap/SwapTransactionSettingsChooser.tsx
+++ b/ui/components/Swap/SwapTransactionSettingsChooser.tsx
@@ -98,8 +98,8 @@ export default function SwapTransactionSettingsChooser({
           </SharedSlideUpMenu>
 
           <div className="top_label label">
-            Transaction settings
-            <button type="button" onClick={openSettings}>
+            <label htmlFor="open-settings">Transaction settings</label>
+            <button type="button" id="open-settings" onClick={openSettings}>
               <span className="icon_cog" />
             </button>
           </div>
@@ -131,6 +131,9 @@ export default function SwapTransactionSettingsChooser({
           }
           .top_label {
             margin-bottom: 7px;
+          }
+          .top_label label {
+            flex-grow: 2;
           }
           .row {
             padding: 15px 0px;

--- a/ui/pages/Onboarding/OnboardingAddWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingAddWallet.tsx
@@ -41,7 +41,7 @@ export default function OnboardingStartTheHunt(): ReactElement {
               size="medium"
               linkTo="/onboarding/importMetamask"
             >
-              Import MetaMask
+              Import recovery phrase
             </SharedButton>
           </li>
         )}

--- a/ui/pages/Onboarding/OnboardingImportMetamask.tsx
+++ b/ui/pages/Onboarding/OnboardingImportMetamask.tsx
@@ -116,8 +116,12 @@ export default function OnboardingImportMetamask(props: Props): ReactElement {
 
   const importWallet = useCallback(async () => {
     const trimmedRecoveryPhrase = recoveryPhrase.trim()
-    if (trimmedRecoveryPhrase.split(" ").length !== 12) {
-      setErrorMessage("Must be a 12-word recovery phrase")
+    const splitTrimmedRecoveryPhrase = trimmedRecoveryPhrase.split(" ")
+    if (
+      splitTrimmedRecoveryPhrase.length !== 12 &&
+      splitTrimmedRecoveryPhrase.length !== 24
+    ) {
+      setErrorMessage("Must be a 12 or 24 word recovery phrase")
     } else if (isValidMnemonic(trimmedRecoveryPhrase)) {
       setIsImporting(true)
       dispatch(importKeyring({ mnemonic: trimmedRecoveryPhrase, path }))

--- a/ui/pages/Onboarding/OnboardingImportMetamask.tsx
+++ b/ui/pages/Onboarding/OnboardingImportMetamask.tsx
@@ -144,7 +144,7 @@ export default function OnboardingImportMetamask(props: Props): ReactElement {
             <div className="metamask_onboarding_image" />
             <h1 className="serif_header">Import account</h1>
             <div className="info">
-              Copy paste or write down your MetaMask secret recovery phrase.
+              Copy paste or write down a 12 or 24 word secret recovery phrase.
             </div>
             <div>
               <TextArea

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement } from "react"
 import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
-import {
-  getAccountTotal,
-} from "@tallyho/tally-background/redux-slices/selectors"
+import { getAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   rejectDataSignature,
   signData,
@@ -24,15 +22,172 @@ interface SignDataLocationState {
   internal: boolean
 }
 
-const CONFIGURABLE_INFO: Record<SignDataMessageType, {
-  title: string,
-}> = {
+const Divider: React.FC<{ spacing?: boolean }> = ({ spacing }) => (
+  <>
+    <div className={`divider ${spacing ? "spacing" : ""}`} />
+    <style jsx>{`
+      .divider {
+        width: 80%;
+        height: 2px;
+        opacity: 60%;
+        background-color: var(--green-120);
+      }
+      .spacing {
+        margin: 16px 0;
+      }
+    `}</style>
+  </>
+)
+
+const EIP191Info: React.FC<{
+  signingData: SignDataRequest["signingData"]
+  account: string
+  internal: boolean
+}> = ({ signingData, account, internal }) => {
+  return (
+    <>
+      <div className="label header">
+        {internal
+          ? "Your signature is required"
+          : "A dapp is requesting your signature"}
+      </div>
+      <Divider />
+      <Divider />
+      <div className="message">
+        <div className="message-title">Message</div>
+        <div className="light">{`${signingData}`}</div>
+      </div>
+      <div className="message">
+        <div className="signed">Signed,</div>
+        <div>{account ?? "Unknown"}</div>
+      </div>
+      <style jsx>{`
+        .message {
+          margin: 16px;
+          font-size: 14px;
+          width: 100%;
+          line-break: anywhere;
+        }
+        .message-title {
+          color: var(--green-40);
+          margin-bottom: 6px;
+        }
+        .light {
+          color: #ccd3d3;
+        }
+        .label {
+          color: var(--green-40);
+        }
+        .header {
+          padding: 16px 0;
+        }
+        .signed {
+          margin-bottom: 6px;
+        }
+      `}</style>
+    </>
+  )
+}
+
+const LabelWithContent: React.FC<{
+  label: string
+  content: string
+}> = ({ label, content }) => {
+  return (
+    <>
+      <div className="wrapper">
+        <div className="label">{label}:</div>
+        <div className="content">{content}</div>
+      </div>
+      <style jsx>{`
+        .wrapper {
+          display: flex;
+          justify-content: space-between;
+          width: 100%;
+          font-size: 16px;
+          line-height: 24px;
+        }
+        .content {
+          color: var(--green-20);
+        }
+      `}</style>
+    </>
+  )
+}
+
+// can add more probably needs to come from a config var though
+const CHAIN_NAMES: (chain: number) => string = (chain) => {
+  switch (chain) {
+    case 1:
+      return "Ethereum"
+    default:
+      return "Unknown"
+  }
+}
+
+// this overides the type to expect EIP4361Data
+const EIP4361Info: React.FC<{ signingData: EIP4361Data }> = ({
+  signingData,
+}) => {
+  return (
+    <>
+      <div className="domain">{signingData.domain}</div>
+      <Divider spacing />
+      <div className="subtext">
+        Wants you to sign in with your
+        <br />
+        Ethereum account:
+      </div>
+      <div className="address">{signingData.address}</div>
+      <Divider spacing />
+      {signingData?.statement ? (
+        <LabelWithContent label="Statement" content={signingData.statement} />
+      ) : null}
+      <LabelWithContent label="Nonce" content={signingData.nonce} />
+      <LabelWithContent label="Version" content={signingData.version} />
+      <LabelWithContent
+        label="Chain ID"
+        content={`${signingData.chainId.toString()} (${CHAIN_NAMES(
+          signingData.chainId
+        )})`}
+      />
+      {signingData?.expiration ? (
+        <LabelWithContent label="Expiration" content={signingData.expiration} />
+      ) : null}
+      <style jsx>{`
+        .subtext {
+          color: var(--green-40);
+          line-height: 24px;
+          font-size: 16px;
+          margin-bottom: 4px;
+        }
+        .domain,
+        .address,
+        .subtext {
+          text-align: center;
+        }
+        .address {
+          line-break: anywhere;
+          max-width: 80%;
+          font-size: 16px;
+        }
+      `}</style>
+    </>
+  )
+}
+
+const CONFIGURABLE_INFO: Record<
+  SignDataMessageType,
+  {
+    title: string
+  }
+> = {
   [SignDataMessageType.EIP4361]: {
-    title: 'Sign in with Ethereum',
+    title: "Sign in with Ethereum",
   },
   [SignDataMessageType.EIP191]: {
-    title: 'Sign Message',
-  }
+    title: "Sign Message",
+  },
 }
 
 export default function PersonalSignData({
@@ -83,21 +238,33 @@ export default function PersonalSignData({
       <SignTransactionNetworkAccountInfoTopBar
         accountTotal={signerAccountTotal}
       />
-      <h1 className="serif_header title">{CONFIGURABLE_INFO[signingDataRequest.messageType].title}</h1>
+      <h1 className="serif_header title">
+        {CONFIGURABLE_INFO[signingDataRequest.messageType].title}
+      </h1>
       <div className="primary_info_card standard_width">
         <div className="sign_block">
           <div className="container">
-            {
-              (() => {
-                switch (signingDataRequest.messageType) {
-                  case SignDataMessageType.EIP4361:
-                    return <EIP4361Info {...signingDataRequest} signingData={signingDataRequest.signingData as EIP4361Data} internal={internal} />
-                  case SignDataMessageType.EIP191:
-                  default:
-                    return <EIP191Info {...signingDataRequest} internal={internal} />
-                }
-              })()
-            }
+            {(() => {
+              switch (signingDataRequest.messageType) {
+                case SignDataMessageType.EIP4361:
+                  return (
+                    <EIP4361Info
+                      signingData={
+                        signingDataRequest.signingData as EIP4361Data
+                      }
+                    />
+                  )
+                case SignDataMessageType.EIP191:
+                default:
+                  return (
+                    <EIP191Info
+                      account={signingDataRequest.account}
+                      internal={internal}
+                      signingData={signingDataRequest.signingData}
+                    />
+                  )
+              }
+            })()}
           </div>
         </div>
       </div>
@@ -182,154 +349,5 @@ export default function PersonalSignData({
         `}
       </style>
     </section>
-  )
-}
-
-const Divider: React.FC<{ spacing?: boolean }> = ({ spacing }) => (
-  <>
-    <div className={`divider ${spacing ? 'spacing' : ''}`}/>
-  <style jsx>{`
-    .divider {
-      width: 80%;
-      height: 2px;
-      opacity: 60%;
-      background-color: var(--green-120);
-    }
-    .spacing {
-      margin: 16px 0;
-    }
-  `}</style>
-  </>
-)
-
-
-const EIP191Info: React.FC<SignDataRequest & { internal: boolean }> = ({
-  signingData,
-  account,
-  internal 
-}) => {
-  return (
-    <>
-      <div className="label header">
-        {internal
-          ? "Your signature is required"
-          : "A dapp is requesting your signature"}
-      </div>
-      <Divider />
-      <Divider />
-      <div className="message">
-        <div className="message-title">Message</div>
-        <div className="light">{`${signingData}`}</div>
-      </div>
-      <div className="message">
-        <div className="signed">Signed,</div>
-        <div>{account ?? "Unknown"}</div>
-      </div>
-      <style jsx>{`
-        .message {
-          margin: 16px;
-          font-size: 14px;
-          width: 100%;
-          line-break: anywhere;
-        }
-        .message-title {
-          color: var(--green-40);
-          margin-bottom: 6px;
-        }
-        .light {
-          color: #ccd3d3;
-        }
-        .label {
-          color: var(--green-40);
-        }
-        .header {
-          padding: 16px 0;
-        }
-        .signed {
-          margin-bottom: 6px;
-        }
-      `}</style>
-    </>
-  )
-}
-
-const LabelWithContent: React.FC<{
-  label: string,
-  content:string,
-}> = ({ label, content }) => {
-  return (
-    <>
-      <div className="wrapper">
-        <div className="label">{label}:</div>
-        <div className="content">{content}</div>
-      </div>
-      <style jsx>{`
-        .wrapper {
-          display: flex;
-          justify-content: space-between;
-          width: 100%;
-          font-size: 16px;
-          line-height: 24px;
-        }
-        .content {
-          color: var(--green-20);
-        }
-      `}</style>
-    </>
-  )
-
-}
-
-// can add more probably needs to come from a config var though
-const CHAIN_NAMES: (chain: number) => string = (chain) => {
-  switch (chain) {
-    case 1:
-      return 'Ethereum'
-    default:
-      return 'Unknown'
-  }
-}
-
-// this overides the type to expect EIP4361Data
-const EIP4361Info: React.FC<SignDataRequest & { internal: boolean, signingData: EIP4361Data }> = ({
-  signingData,
-}) => {
-  return (
-    <>
-      <div className="domain">{signingData.domain}</div>
-      <Divider spacing={true} />
-      <div className="subtext">Wants you to sign in with your<br/>Ethereum account:</div>
-      <div className="address">{signingData.address}</div>
-      <Divider spacing={true} />
-      {
-        signingData?.statement
-          ? <LabelWithContent label={'Statement'} content={signingData.statement}/>
-          : null
-      }
-      <LabelWithContent label={'Nonce'} content={signingData.nonce}/>
-      <LabelWithContent label={'Version'} content={signingData.version}/>
-      <LabelWithContent label={'Chain ID'} content={`${signingData.chainId.toString()} (${CHAIN_NAMES(signingData.chainId)})`}/>
-      {
-        signingData?.expiration
-          ? <LabelWithContent label={'Expiration'} content={signingData.expiration}/>
-          : null
-      }
-      <style jsx>{`
-        .subtext {
-          color: var(--green-40);
-          line-height: 24px;
-          font-size: 16px;
-          margin-bottom: 4px;
-        }
-        .domain, .address, .subtext {
-          text-align: center;
-        }
-        .address {
-          line-break: anywhere;
-          max-width: 80%;
-          font-size: 16px;
-        }
-      `}</style>
-    </>
   )
 }

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -1,0 +1,215 @@
+import React, { ReactElement } from "react"
+import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
+import { getAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
+import {
+  rejectDataSignature,
+  signData,
+  selectSigningData,
+} from "@tallyho/tally-background/redux-slices/signing"
+import { useHistory } from "react-router-dom"
+import SharedButton from "../components/Shared/SharedButton"
+import SignTransactionNetworkAccountInfoTopBar from "../components/SignTransaction/SignTransactionNetworkAccountInfoTopBar"
+import {
+  useAreKeyringsUnlocked,
+  useBackgroundDispatch,
+  useBackgroundSelector,
+} from "../hooks"
+
+interface SignDataLocationState {
+  internal: boolean
+}
+
+export default function PersonalSignData({
+  location,
+}: {
+  location: { state?: SignDataLocationState }
+}): ReactElement {
+  const dispatch = useBackgroundDispatch()
+  
+  const signingDataRequest = useBackgroundSelector(selectSigningData)
+  console.log("data", signingDataRequest)
+
+  const history = useHistory()
+
+  const { internal } = location.state ?? {
+    internal: false,
+  }
+
+  const areKeyringsUnlocked = useAreKeyringsUnlocked(true)
+
+  const signerAccountTotal = useBackgroundSelector((state) => {
+    if (typeof signingDataRequest !== "undefined") {
+      return getAccountTotal(state, signingDataRequest.account)
+    }
+    return undefined
+  })
+  if (
+    !areKeyringsUnlocked ||
+    typeof signingDataRequest === "undefined" ||
+    typeof signerAccountTotal === "undefined"
+  ) {
+    return <></>
+  }
+  const message = signingDataRequest?.signingData
+
+  const handleConfirm = () => {
+    if (signingDataRequest !== undefined) {
+      dispatch(signData(signingDataRequest))
+    }
+  }
+
+  const handleReject = async () => {
+    dispatch(rejectDataSignature())
+    history.goBack()
+  }
+  return (
+    <section>
+      <SignTransactionNetworkAccountInfoTopBar
+        accountTotal={signerAccountTotal}
+      />
+      <h1 className="serif_header title">{`Sign Message`}</h1>
+      <div className="primary_info_card standard_width">
+        <div className="sign_block">
+          <div className="container">
+            <div className="label header">
+              {internal
+                ? "Your signature is required"
+                : "A dapp is requesting your signature"}
+            </div>
+            <div className="divider" />
+            <div className="divider" />
+            <div className="single_message">
+              <div className="light">{`${message}`}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="footer_actions">
+        <SharedButton
+          iconSize="large"
+          size="large"
+          type="secondary"
+          onClick={handleReject}
+        >
+          Reject
+        </SharedButton>
+        {signerAccountTotal?.accountType === AccountType.Imported ? (
+          <SharedButton
+            type="primary"
+            iconSize="large"
+            size="large"
+            onClick={handleConfirm}
+            showLoadingOnClick
+          >
+            Sign
+          </SharedButton>
+        ) : (
+          <span className="no-signing">Read-only accounts cannot sign</span>
+        )}
+      </div>
+      <style jsx>
+        {`
+          section {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            background-color: var(--green-95);
+            z-index: 5;
+          }
+          .title {
+            color: var(--trophy-gold);
+            font-size: 36px;
+            font-weight: 500;
+            line-height: 42px;
+            text-align: center;
+          }
+          .primary_info_card {
+            display: block;
+            height: fit-content;
+            border-radius: 16px;
+            background-color: var(--hunter-green);
+            margin: 16px 0px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+          }
+          .footer_actions {
+            position: fixed;
+            bottom: 0px;
+            display: flex;
+            width: 100%;
+            padding: 0px 16px;
+            box-sizing: border-box;
+            align-items: center;
+            height: 80px;
+            justify-content: space-between;
+            box-shadow: 0 0 5px rgba(0, 20, 19, 0.5);
+            background-color: var(--green-95);
+          }
+          .sign_block {
+            display: flex;
+            width: 100%;
+            flex-direction: column;
+            justify-content: space-between;
+          }
+          .label {
+            color: var(--green-40);
+          }
+          .header {
+            padding: 16px 0;
+          }
+          .messages {
+            display: flex;
+            flex-flow: column;
+            width: 100%;
+            padding-top: 16px;
+          }
+          .message {
+            display: flex;
+            justify-content: space-between;
+            padding: 6px 16px;
+          }
+          .value {
+            overflow-wrap: anywhere;
+            max-width: 220px;
+            text-align: right;
+          }
+          .light {
+            color: #ccd3d3;
+          }
+          .key {
+            color: var(--green-40);
+          }
+          .divider {
+            width: 80%;
+            height: 2px;
+            opacity: 60%;
+            background-color: var(--green-120);
+          }
+          .single_message {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+            text-align: left;
+            padding: 16px;
+            width: 80%;
+          }
+          .divider {
+            width: 80%;
+            height: 2px;
+            opacity: 60%;
+            background-color: var(--green-120);
+          }
+          .container {
+            display: flex;
+            margin: 20px 0;
+            flex-direction: column;
+            align-items: center;
+          }
+        `}
+      </style>
+    </section>
+  )
+}

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement } from "react"
 import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
-import { getAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
+import {
+  getAccountTotal,
+  selectCurrentAccount,
+} from "@tallyho/tally-background/redux-slices/selectors"
 import {
   rejectDataSignature,
   signData,
@@ -25,8 +28,11 @@ export default function PersonalSignData({
   location: { state?: SignDataLocationState }
 }): ReactElement {
   const dispatch = useBackgroundDispatch()
-  
+
   const signingDataRequest = useBackgroundSelector(selectSigningData)
+
+  const account = useBackgroundSelector(selectCurrentAccount)
+
   console.log("data", signingDataRequest)
 
   const history = useHistory()
@@ -43,6 +49,7 @@ export default function PersonalSignData({
     }
     return undefined
   })
+
   if (
     !areKeyringsUnlocked ||
     typeof signingDataRequest === "undefined" ||
@@ -50,6 +57,7 @@ export default function PersonalSignData({
   ) {
     return <></>
   }
+
   const message = signingDataRequest?.signingData
 
   const handleConfirm = () => {
@@ -67,7 +75,7 @@ export default function PersonalSignData({
       <SignTransactionNetworkAccountInfoTopBar
         accountTotal={signerAccountTotal}
       />
-      <h1 className="serif_header title">{`Sign Message`}</h1>
+      <h1 className="serif_header title">Sign Message</h1>
       <div className="primary_info_card standard_width">
         <div className="sign_block">
           <div className="container">
@@ -78,8 +86,13 @@ export default function PersonalSignData({
             </div>
             <div className="divider" />
             <div className="divider" />
-            <div className="single_message">
+            <div className="message">
+              <div className="message-title">Message</div>
               <div className="light">{`${message}`}</div>
+            </div>
+            <div className="message">
+              <div className="signed">Signed,</div>
+              <div className="name">{account?.address ?? "Unknown"}</div>
             </div>
           </div>
         </div>
@@ -148,6 +161,9 @@ export default function PersonalSignData({
             box-shadow: 0 0 5px rgba(0, 20, 19, 0.5);
             background-color: var(--green-95);
           }
+          .signed {
+            margin-bottom: 6px;
+          }
           .sign_block {
             display: flex;
             width: 100%;
@@ -167,9 +183,13 @@ export default function PersonalSignData({
             padding-top: 16px;
           }
           .message {
-            display: flex;
-            justify-content: space-between;
-            padding: 6px 16px;
+            margin: 16px;
+            font-size: 14px;
+            line-break: anywhere;
+          }
+          .message-title {
+            color: var(--green-40);
+            margin-bottom: 6px;
           }
           .value {
             overflow-wrap: anywhere;
@@ -181,20 +201,6 @@ export default function PersonalSignData({
           }
           .key {
             color: var(--green-40);
-          }
-          .divider {
-            width: 80%;
-            height: 2px;
-            opacity: 60%;
-            background-color: var(--green-120);
-          }
-          .single_message {
-            display: flex;
-            flex-direction: column;
-            gap: 24px;
-            text-align: left;
-            padding: 16px;
-            width: 80%;
           }
           .divider {
             width: 80%;

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -33,8 +33,6 @@ export default function PersonalSignData({
 
   const account = useBackgroundSelector(selectCurrentAccount)
 
-  console.log("data", signingDataRequest)
-
   const history = useHistory()
 
   const { internal } = location.state ?? {

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -90,7 +90,7 @@ export default function PersonalSignData({
             </div>
             <div className="message">
               <div className="signed">Signed,</div>
-              <div className="name">{account?.address ?? "Unknown"}</div>
+              <div className="name">{signingDataRequest.account ?? "Unknown"}<div>
             </div>
           </div>
         </div>

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -107,6 +107,10 @@ const LabelWithContent: React.FC<{
           font-size: 16px;
           line-height: 24px;
         }
+        .wrapper .label {
+          font-size: 16px;
+
+        }
         .content {
           color: var(--green-20);
         }

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -90,7 +90,7 @@ export default function PersonalSignData({
             </div>
             <div className="message">
               <div className="signed">Signed,</div>
-              <div className="name">{signingDataRequest.account ?? "Unknown"}<div>
+              <div className="name">{signingDataRequest.account ?? "Unknown"}</div>
             </div>
           </div>
         </div>

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -2,12 +2,14 @@ import React, { ReactElement } from "react"
 import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   getAccountTotal,
-  selectCurrentAccount,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   rejectDataSignature,
   signData,
   selectSigningData,
+  SignDataMessageType,
+  SignDataRequest,
+  EIP4361Data,
 } from "@tallyho/tally-background/redux-slices/signing"
 import { useHistory } from "react-router-dom"
 import SharedButton from "../components/Shared/SharedButton"
@@ -22,6 +24,17 @@ interface SignDataLocationState {
   internal: boolean
 }
 
+const CONFIGURABLE_INFO: Record<SignDataMessageType, {
+  title: string,
+}> = {
+  [SignDataMessageType.EIP4361]: {
+    title: 'Sign in with Ethereum',
+  },
+  [SignDataMessageType.EIP191]: {
+    title: 'Sign Message',
+  }
+}
+
 export default function PersonalSignData({
   location,
 }: {
@@ -30,8 +43,6 @@ export default function PersonalSignData({
   const dispatch = useBackgroundDispatch()
 
   const signingDataRequest = useBackgroundSelector(selectSigningData)
-
-  const account = useBackgroundSelector(selectCurrentAccount)
 
   const history = useHistory()
 
@@ -56,8 +67,6 @@ export default function PersonalSignData({
     return <></>
   }
 
-  const message = signingDataRequest?.signingData
-
   const handleConfirm = () => {
     if (signingDataRequest !== undefined) {
       dispatch(signData(signingDataRequest))
@@ -68,30 +77,27 @@ export default function PersonalSignData({
     dispatch(rejectDataSignature())
     history.goBack()
   }
+
   return (
     <section>
       <SignTransactionNetworkAccountInfoTopBar
         accountTotal={signerAccountTotal}
       />
-      <h1 className="serif_header title">Sign Message</h1>
+      <h1 className="serif_header title">{CONFIGURABLE_INFO[signingDataRequest.messageType].title}</h1>
       <div className="primary_info_card standard_width">
         <div className="sign_block">
           <div className="container">
-            <div className="label header">
-              {internal
-                ? "Your signature is required"
-                : "A dapp is requesting your signature"}
-            </div>
-            <div className="divider" />
-            <div className="divider" />
-            <div className="message">
-              <div className="message-title">Message</div>
-              <div className="light">{`${message}`}</div>
-            </div>
-            <div className="message">
-              <div className="signed">Signed,</div>
-              <div className="name">{signingDataRequest.account ?? "Unknown"}</div>
-            </div>
+            {
+              (() => {
+                switch (signingDataRequest.messageType) {
+                  case SignDataMessageType.EIP4361:
+                    return <EIP4361Info {...signingDataRequest} signingData={signingDataRequest.signingData as EIP4361Data} internal={internal} />
+                  case SignDataMessageType.EIP191:
+                  default:
+                    return <EIP191Info {...signingDataRequest} internal={internal} />
+                }
+              })()
+            }
           </div>
         </div>
       </div>
@@ -159,61 +165,171 @@ export default function PersonalSignData({
             box-shadow: 0 0 5px rgba(0, 20, 19, 0.5);
             background-color: var(--green-95);
           }
-          .signed {
-            margin-bottom: 6px;
-          }
           .sign_block {
             display: flex;
             width: 100%;
             flex-direction: column;
             justify-content: space-between;
           }
-          .label {
-            color: var(--green-40);
-          }
-          .header {
-            padding: 16px 0;
-          }
-          .messages {
-            display: flex;
-            flex-flow: column;
-            width: 100%;
-            padding-top: 16px;
-          }
-          .message {
-            margin: 16px;
-            font-size: 14px;
-            line-break: anywhere;
-          }
-          .message-title {
-            color: var(--green-40);
-            margin-bottom: 6px;
-          }
-          .value {
-            overflow-wrap: anywhere;
-            max-width: 220px;
-            text-align: right;
-          }
-          .light {
-            color: #ccd3d3;
-          }
-          .key {
-            color: var(--green-40);
-          }
-          .divider {
-            width: 80%;
-            height: 2px;
-            opacity: 60%;
-            background-color: var(--green-120);
-          }
           .container {
             display: flex;
-            margin: 20px 0;
+            margin: 20px 16px;
             flex-direction: column;
             align-items: center;
+            font-size: 16px;
+            line-height: 24px;
           }
         `}
       </style>
     </section>
+  )
+}
+
+const Divider: React.FC<{ spacing?: boolean }> = ({ spacing }) => (
+  <>
+    <div className={`divider ${spacing ? 'spacing' : ''}`}/>
+  <style jsx>{`
+    .divider {
+      width: 80%;
+      height: 2px;
+      opacity: 60%;
+      background-color: var(--green-120);
+    }
+    .spacing {
+      margin: 16px 0;
+    }
+  `}</style>
+  </>
+)
+
+
+const EIP191Info: React.FC<SignDataRequest & { internal: boolean }> = ({
+  signingData,
+  account,
+  internal 
+}) => {
+  return (
+    <>
+      <div className="label header">
+        {internal
+          ? "Your signature is required"
+          : "A dapp is requesting your signature"}
+      </div>
+      <Divider />
+      <Divider />
+      <div className="message">
+        <div className="message-title">Message</div>
+        <div className="light">{`${signingData}`}</div>
+      </div>
+      <div className="message">
+        <div className="signed">Signed,</div>
+        <div>{account ?? "Unknown"}</div>
+      </div>
+      <style jsx>{`
+        .message {
+          margin: 16px;
+          font-size: 14px;
+          width: 100%;
+          line-break: anywhere;
+        }
+        .message-title {
+          color: var(--green-40);
+          margin-bottom: 6px;
+        }
+        .light {
+          color: #ccd3d3;
+        }
+        .label {
+          color: var(--green-40);
+        }
+        .header {
+          padding: 16px 0;
+        }
+        .signed {
+          margin-bottom: 6px;
+        }
+      `}</style>
+    </>
+  )
+}
+
+const LabelWithContent: React.FC<{
+  label: string,
+  content:string,
+}> = ({ label, content }) => {
+  return (
+    <>
+      <div className="wrapper">
+        <div className="label">{label}:</div>
+        <div className="content">{content}</div>
+      </div>
+      <style jsx>{`
+        .wrapper {
+          display: flex;
+          justify-content: space-between;
+          width: 100%;
+          font-size: 16px;
+          line-height: 24px;
+        }
+        .content {
+          color: var(--green-20);
+        }
+      `}</style>
+    </>
+  )
+
+}
+
+// can add more probably needs to come from a config var though
+const CHAIN_NAMES: (chain: number) => string = (chain) => {
+  switch (chain) {
+    case 1:
+      return 'Ethereum'
+    default:
+      return 'Unknown'
+  }
+}
+
+// this overides the type to expect EIP4361Data
+const EIP4361Info: React.FC<SignDataRequest & { internal: boolean, signingData: EIP4361Data }> = ({
+  signingData,
+}) => {
+  return (
+    <>
+      <div className="domain">{signingData.domain}</div>
+      <Divider spacing={true} />
+      <div className="subtext">Wants you to sign in with your<br/>Ethereum account:</div>
+      <div className="address">{signingData.address}</div>
+      <Divider spacing={true} />
+      {
+        signingData?.statement
+          ? <LabelWithContent label={'Statement'} content={signingData.statement}/>
+          : null
+      }
+      <LabelWithContent label={'Nonce'} content={signingData.nonce}/>
+      <LabelWithContent label={'Version'} content={signingData.version}/>
+      <LabelWithContent label={'Chain ID'} content={`${signingData.chainId.toString()} (${CHAIN_NAMES(signingData.chainId)})`}/>
+      {
+        signingData?.expiration
+          ? <LabelWithContent label={'Expiration'} content={signingData.expiration}/>
+          : null
+      }
+      <style jsx>{`
+        .subtext {
+          color: var(--green-40);
+          line-height: 24px;
+          font-size: 16px;
+          margin-bottom: 4px;
+        }
+        .domain, .address, .subtext {
+          text-align: center;
+        }
+        .address {
+          line-break: anywhere;
+          max-width: 80%;
+          font-size: 16px;
+        }
+      `}</style>
+    </>
   )
 }

--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -66,9 +66,7 @@ export function Main(): ReactElement {
   const [showTabBar, setShowTabBar] = useState(true)
   const renderCount = useRef(0)
 
-  const routeHistoryEntries = useBackgroundSelector((state) => {
-    return state.ui.routeHistoryEntries
-  })
+  const routeHistoryEntries = useBackgroundSelector((state) => state.ui.routeHistoryEntries)
 
   function saveHistoryEntries(routeHistoryEntities: Location[]) {
     const isNotOnKeyringRelatedPage =

--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -66,7 +66,9 @@ export function Main(): ReactElement {
   const [showTabBar, setShowTabBar] = useState(true)
   const renderCount = useRef(0)
 
-  const routeHistoryEntries = useBackgroundSelector((state) => state.ui.routeHistoryEntries)
+  const routeHistoryEntries = useBackgroundSelector(
+    (state) => state.ui.routeHistoryEntries
+  )
 
   function saveHistoryEntries(routeHistoryEntities: Location[]) {
     const isNotOnKeyringRelatedPage =

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -84,7 +84,6 @@ export default function SignData({
                 : "A dapp is requesting your signature"}
             </div>
             <div className="divider" />
-            <div className="header">{domain.name}</div>
             <div className="divider" />
             {keys.length > 2 ? (
               <div className="messages">

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -25,7 +25,7 @@ import { AsyncThunkFulfillmentType } from "@tallyho/tally-background/redux-slice
 import logger from "@tallyho/tally-background/lib/logger"
 import { useHistory, useLocation } from "react-router-dom"
 import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
-import { SmartContractFungibleCompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
+import { CompleteSmartContractFungibleAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   clearTransactionState,
   selectDefaultNetworkFeeSettings,
@@ -77,14 +77,13 @@ export default function Swap(): ReactElement {
 
   // TODO Expand these to fungible assets by supporting direct ETH swaps,
   // TODO then filter by the current chain.
-  let ownedSellAssetAmounts: SmartContractFungibleCompleteAssetAmount[] = []
 
-  if (typeof accountBalances !== "undefined") {
-    ownedSellAssetAmounts = accountBalances.assetAmounts.filter(
-      (assetAmount): assetAmount is SmartContractFungibleCompleteAssetAmount =>
+  const ownedSellAssetAmounts =
+    accountBalances?.assetAmounts.filter(
+      (assetAmount): assetAmount is CompleteSmartContractFungibleAssetAmount =>
         isSmartContractFungibleAsset(assetAmount.asset)
-    )
-  }
+    ) ?? []
+
   const buyAssets = useBackgroundSelector((state) => {
     // Some type massaging needed to remind TypeScript how these types fit
     // together.

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -14,10 +14,9 @@ import {
   SwapQuoteRequest,
   fetchSwapQuote,
 } from "@tallyho/tally-background/redux-slices/0x-swap"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
+import { selectCurrentAccountBalances } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   AnyAsset,
-  AnyAssetAmount,
   isSmartContractFungibleAsset,
   SmartContractFungibleAsset,
 } from "@tallyho/tally-background/assets"
@@ -26,7 +25,7 @@ import { AsyncThunkFulfillmentType } from "@tallyho/tally-background/redux-slice
 import logger from "@tallyho/tally-background/lib/logger"
 import { useHistory, useLocation } from "react-router-dom"
 import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
-import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
+import { SmartContractFungibleCompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   clearTransactionState,
   selectDefaultNetworkFeeSettings,
@@ -74,25 +73,18 @@ export default function Swap(): ReactElement {
     { symbol: string; contractAddress?: string } | undefined
   >()
 
-  const { combinedData } = useBackgroundSelector(
-    selectAccountAndTimestampedActivities
-  )
+  const accountBalances = useBackgroundSelector(selectCurrentAccountBalances)
 
   // TODO Expand these to fungible assets by supporting direct ETH swaps,
   // TODO then filter by the current chain.
-  const ownedSellAssetAmounts = combinedData.assets.filter<
-    CompleteAssetAmount<
-      SmartContractFungibleAsset,
-      AnyAssetAmount<SmartContractFungibleAsset>
-    >
-  >(
-    (
-      assetAmount
-    ): assetAmount is CompleteAssetAmount<
-      SmartContractFungibleAsset,
-      AnyAssetAmount<SmartContractFungibleAsset>
-    > => isSmartContractFungibleAsset(assetAmount.asset)
-  )
+  let ownedSellAssetAmounts: SmartContractFungibleCompleteAssetAmount[] = []
+
+  if (typeof accountBalances !== "undefined") {
+    ownedSellAssetAmounts = accountBalances.assetAmounts.filter(
+      (assetAmount): assetAmount is SmartContractFungibleCompleteAssetAmount =>
+        isSmartContractFungibleAsset(assetAmount.asset)
+    )
+  }
   const buyAssets = useBackgroundSelector((state) => {
     // Some type massaging needed to remind TypeScript how these types fit
     // together.

--- a/ui/routes/routes.tsx
+++ b/ui/routes/routes.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react"
 import Wallet from "../pages/Wallet"
 import SignTransaction from "../pages/SignTransaction"
 import SignData from "../pages/SignData"
+import PersonalSign from "../pages/PersonalSign"
 import OnboardingSaveSeed from "../pages/Onboarding/OnboardingSaveSeed"
 import OnboardingVerifySeed from "../pages/Onboarding/OnboardingVerifySeed"
 import OnboardingImportMetamask from "../pages/Onboarding/OnboardingImportMetamask"
@@ -91,6 +92,13 @@ const pageList: PageList[] = [
   {
     path: "/signData",
     Component: SignData,
+    hasTabBar: false,
+    hasTopBar: false,
+    persistOnClose: false,
+  },
+  {
+    path: "/personalSign",
+    Component: PersonalSign,
     hasTabBar: false,
     hasTopBar: false,
     persistOnClose: false,

--- a/ui/routes/routes.tsx
+++ b/ui/routes/routes.tsx
@@ -101,7 +101,7 @@ const pageList: PageList[] = [
     Component: PersonalSign,
     hasTabBar: false,
     hasTopBar: false,
-    persistOnClose: false,
+    persistOnClose: true,
   },
   {
     path: "/overview",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2298,6 +2298,31 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@stablelib/binary@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/binary/-/binary-1.0.1.tgz#c5900b94368baf00f811da5bdb1610963dfddf7f"
+  integrity sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==
+  dependencies:
+    "@stablelib/int" "^1.0.1"
+
+"@stablelib/int@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/int/-/int-1.0.1.tgz#75928cc25d59d73d75ae361f02128588c15fd008"
+  integrity sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==
+
+"@stablelib/random@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/random/-/random-1.0.1.tgz#4357a00cb1249d484a9a71e6054bc7b8324a7009"
+  integrity sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/wipe@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/wipe/-/wipe-1.0.1.tgz#d21401f1d59ade56a62e139462a97f104ed19a36"
+  integrity sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==
+
 "@tallyho/hd-keyring@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@tallyho/hd-keyring/-/hd-keyring-0.3.3.tgz#41b61cba5e0552fad6d3b9a2bef8cabfd661e1bb"
@@ -3116,6 +3141,11 @@ anymatch@^3.0.0, anymatch@^3.0.3, anymatch@^3.1.1, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+apg-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/apg-js/-/apg-js-4.1.1.tgz#5ee8a74e26517073e1bda66705eca6fc22b305e2"
+  integrity sha512-DwTfzx1YuCrnEvywiU/AYKiX8Y6JzhY8PwaM9syh54zzBPaHzonN7c4YsAspC6YcdSu/jfBXBJ1S9hj1QsiePA==
 
 apollo-cache-control@^0.1.0:
   version "0.1.1"
@@ -10409,6 +10439,15 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+siwe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/siwe/-/siwe-1.1.0.tgz#46ed70913159a3948ad8f15d1b517f5fefc59c52"
+  integrity sha512-dOv8Y3756kdE5sdXdqvyAJzvIub+e4dGtY7TVdMeu6/PzK+Bu9do2kcXga2zgunZW0eiM2N9Hd0+u0Wd5OLitg==
+  dependencies:
+    "@stablelib/random" "^1.0.1"
+    apg-js "^4.1.1"
+    ethers "^5.5.1"
 
 size-plugin@^2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5161,6 +5161,11 @@ eslint-plugin-jsx-a11y@^6.4.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
+eslint-plugin-no-only-tests@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz#19f6c9620bda02b9b9221b436c5f070e42628d76"
+  integrity sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
+
 eslint-plugin-prettier@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz#e9ddb200efb6f3d05ffe83b1665a716af4a387e5"


### PR DESCRIPTION
Implementation of [EIP4361 Ethereum Sign-In](https://eips.ethereum.org/EIPS/eip-4361)

Extension of EIP191 implemented https://github.com/tallycash/extension/pull/995.

## Changes
- detect EIP4361 sign in messages and handle accordingly
- allow for additional message structures in the future
- convert hex message string to ascii
- create different pages different message types 

<img width="384" alt="Screen Shot 2022-02-20 at 3 03 43 am" src="https://user-images.githubusercontent.com/29347276/154810972-4eba5f75-6ff2-49ea-8500-f876e16d22bd.png">
